### PR TITLE
Fix path vs short_path in scripts

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -13,7 +13,7 @@ def _buildifier_binary(ctx):
 #!/usr/bin/env bash
 
 exec {buildifier} "$@"
-""".format(buildifier = buildifier.short_path),
+""".format(buildifier = buildifier.path),
         is_executable = True,
     )
 
@@ -40,7 +40,7 @@ def _buildozer_binary(ctx):
 #!/usr/bin/env bash
 
 exec {buildozer} "$@"
-""".format(buildozer = buildozer.short_path),
+""".format(buildozer = buildozer.path),
         is_executable = True,
     )
 


### PR DESCRIPTION
If you run this script as part of another bazel rule's data attribute,
this relative path was incorrect.