### PR TITLE
Implement release GitHub Actions workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,56 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+      reset_tag:
+        type: boolean
+        default: false
+      base_branch:
+        description: The branch being merged to.
+        type: string
+        default: main
+  workflow_call:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+      reset_tag:
+        type: boolean
+        default: false
+      base_branch:
+        description: The branch being merged to.
+        type: string
+        default: main
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+
+    steps:
+      # Checkout the code
+      - uses: actions/checkout@v2
+
+      # Generate a token that has permission to create a PR
+      - uses: tibdex/github-app-token@v1
+        id: generate_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      # Set up the git user to create a comiit (e.g. set user.name and user.email)
+      - uses: cgrindel/gha_configure_git_user@v1
+
+      # Create the release
+      - uses: cgrindel/gha_create_release@v1
+        with:
+          release_tag: ${{  github.event.inputs.release_tag }}
+          reset_tag: ${{  github.event.inputs.reset_tag }}
+          base_branch: ${{  github.event.inputs.base_branch }}
+          github_token: ${{ steps.generate_token.outputs.token }}
+

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -13,18 +13,6 @@ on:
         description: The branch being merged to.
         type: string
         default: main
-  workflow_call:
-    inputs:
-      release_tag:
-        required: true
-        type: string
-      reset_tag:
-        type: boolean
-        default: false
-      base_branch:
-        description: The branch being merged to.
-        type: string
-        default: main
 
 jobs:
   create_release:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -24,7 +24,7 @@ jobs:
       # Checkout the code
       - uses: actions/checkout@v2
 
-      # Generate a token that has permission to create a PR
+      # Generate a token that has permission to create a PR to update the README.md.
       - uses: tibdex/github-app-token@v1
         id: generate_token
         with:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -6,9 +6,6 @@ on:
       release_tag:
         required: true
         type: string
-      reset_tag:
-        type: boolean
-        default: false
       base_branch:
         description: The branch being merged to.
         type: string
@@ -38,7 +35,6 @@ jobs:
       - uses: cgrindel/gha_create_release@v1
         with:
           release_tag: ${{  github.event.inputs.release_tag }}
-          reset_tag: ${{  github.event.inputs.reset_tag }}
           base_branch: ${{  github.event.inputs.base_branch }}
           github_token: ${{ steps.generate_token.outputs.token }}
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ bazel run -- @buildifier_prebuilt//:buildifier ARGS
 
 ## Installation
 
-Checkout [the releases
-page](https://github.com/keith/buildifier-prebuilt/releases) for
-snippets for your WORKSPACE
+Add the following to your `WORKSPACE` file.
+
+<!-- BEGIN WORKSPACE SNIPPET -->
+<!-- END WORKSPACE SNIPPET -->
+
 
 ### Specify Version of Buildtools
 

--- a/release/BUILD
+++ b/release/BUILD
@@ -1,0 +1,29 @@
+load(
+    "@cgrindel_bazel_starlib//bzlrelease:defs.bzl",
+    "create_release",
+    "generate_release_notes",
+    "generate_workspace_snippet",
+    "update_readme",
+)
+
+# MARK: - Release
+
+generate_workspace_snippet(
+    name = "generate_workspace_snippet",
+    template = "workspace_snippet.tmpl",
+)
+
+generate_release_notes(
+    name = "generate_release_notes",
+    generate_workspace_snippet = ":generate_workspace_snippet",
+)
+
+update_readme(
+    name = "update_readme",
+    generate_workspace_snippet = ":generate_workspace_snippet",
+)
+
+create_release(
+    name = "create",
+    workflow_name = "Create Release",
+)

--- a/release/workspace_snippet.tmpl
+++ b/release/workspace_snippet.tmpl
@@ -10,10 +10,6 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
-
-bazel_starlib_dependencies()
-
 load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
 
 buildifier_prebuilt_register_toolchains()

--- a/release/workspace_snippet.tmpl
+++ b/release/workspace_snippet.tmpl
@@ -1,0 +1,19 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+${http_archive_statement}
+
+load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")
+
+buildifier_prebuilt_deps()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
+
+bazel_starlib_dependencies()
+
+load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
+
+buildifier_prebuilt_register_toolchains()


### PR DESCRIPTION
Closes #11.

- Added the `release` package with targets for generating a workspace snippet, release notes, updating the readme, and kicking off the release workflow.
- Added the `create_release.yml` workflow.
- Updated the `README.md` to include the markdown comment markers for the workspace snippet.

To complete the setup, the following needs to be configured for the repository:

1. On the repository `Settings -> General` page, enable `Allow auto-merge`. You may also want to enable `Automatically delete head branches` to reduce the number of branches hanging around.
2. Complete the [Set Up a GitHub App to Generate Tokens](https://github.com/cgrindel/bazel-starlib/tree/main/bzlrelease#set-up-a-github-app-to-generate-tokens). The default Github token provided to a workflow does not have permission to create releases or PRs. The idea is to configure a GitHub app that has the minimum permissions to do these actions.