### PR TITLE
Added daily CI builds and a badge referencing their results.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI for PR Merge
 on:
   pull_request:
     branches: [ main ]
+  schedule:
+    # Every day at 11:03 UTC.
+    - cron: '3 11 * * *'
 
 jobs:
   macos_build:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # buildifier-prebuilt
 
+[![Build](https://github.com/keith/buildifier-prebuilt/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/keith/buildifier-prebuilt/actions/workflows/ci.yml)
+
 This repo contains bazel rules for `buildifier` and `buildozer` using
 prebuilt binaries with bazel toolchains instead of requiring you depend
 on `rules_go`. This also means you won't download every possible version


### PR DESCRIPTION
I have been adding daily builds to my repositories and pointing a build badge to the scheduled builds, not the PR merge builds. The hope is to provide some level of certainty to interested clients that the project is in working order.