### PR TITLE
Added release `README.md`, moved bazel-starlib download, and bumped bazel-starlib version.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,9 +16,18 @@ load(":defs.bzl", "buildifier_prebuilt_register_toolchains")
 
 buildifier_prebuilt_register_toolchains()
 
-# MARK: - Test Dependencies
+# MARK: - Test and Release Dependencies
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "cgrindel_bazel_starlib",
+    sha256 = "fc2ee0fce914e3aee1a6af460d4ba1eed9d82e8125294d14e7d3f236d4a10a5d",
+    strip_prefix = "bazel-starlib-0.3.2",
+    urls = [
+        "http://github.com/cgrindel/bazel-starlib/archive/v0.3.2.tar.gz",
+    ],
+)
 
 http_archive(
     name = "cgrindel_rules_bazel_integration_test",

--- a/deps.bzl
+++ b/deps.bzl
@@ -11,13 +11,3 @@ def buildifier_prebuilt_deps():
         ],
         sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
     )
-
-    maybe(
-        http_archive,
-        name = "cgrindel_bazel_starlib",
-        sha256 = "fc2ee0fce914e3aee1a6af460d4ba1eed9d82e8125294d14e7d3f236d4a10a5d",
-        strip_prefix = "bazel-starlib-0.3.2",
-        urls = [
-            "http://github.com/cgrindel/bazel-starlib/archive/v0.3.2.tar.gz",
-        ],
-    )

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,32 @@
+# Release Process for buildifier-prebuilt
+
+This document describes how to create a release.
+
+
+## How to Create a Release
+
+Once all of the code for a release has been merged to `main`, the release process can be started
+using the command line or the GitHub Actions web interface.
+
+
+### Create Release from Command Line
+
+The release process can be started by executing the `//release:create` target specifying the desired
+release tag (e.g. 1.2.3). To create a release tagged with `0.1.4`, one would run the following:
+
+```sh
+# Launch release GitHub Actions release workflow for 0.1.4
+$ bazel run //release:create -- 0.1.4
+```
+
+## Create Release from GitHub Actions Web Interface
+
+To start the release process from the GitHub Actions web interface, 
+
+1. Navigate to the [Create
+   Release](https://github.com/keith/buildifier-prebuilt/actions/workflows/create_release.yml)
+   workflow page. 
+2. Click the `Run workflow` dropdown button. It is located on the right-hand side of the page under
+   the workflow execution filter controls.
+3. In the `release_tag` textbox, enter the release tag that should be created (e.g. `1.2.3`).
+4. Click the green `Run workflow` button.


### PR DESCRIPTION
Related to #11.

I realized that I failed to add a `README.md` to the `release` package describing how to do the release. While writing it up, I noticed that your version tags don't have the `v` prefix. I updated `bazel-starlib` to not require this and ran a new release. Also, I realized that `bazel-starlib` was still in `deps.bzl`. So, I moved it to the `WORKSPACE`.