### PR TITLE
Upgraded bazel-starlib and added custom workspace name to workspace snippet generation.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,10 +18,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "cgrindel_bazel_starlib",
-    sha256 = "57453a08f932633375e630c1553f9e93c1edebe733836d4a6de6fd37c7869680",
-    strip_prefix = "bazel-starlib-0.4.1",
+    sha256 = "75ede4943a0000661cab0a4495bd10ddfc45bc73df83677eb75f49202ea09a34",
+    strip_prefix = "bazel-starlib-0.5.0",
     urls = [
-        "http://github.com/cgrindel/bazel-starlib/archive/v0.4.1.tar.gz",
+        "http://github.com/cgrindel/bazel-starlib/archive/v0.5.0.tar.gz",
     ],
 )
 

--- a/release/BUILD
+++ b/release/BUILD
@@ -11,6 +11,7 @@ load(
 generate_workspace_snippet(
     name = "generate_workspace_snippet",
     template = "workspace_snippet.tmpl",
+    workspace_name = "buildifier_prebuilt",
 )
 
 generate_release_notes(


### PR DESCRIPTION
Related to cgrindel/bazel-starlib#106.

- Upgraded `bazel-starlib` to v0.5.0.
- Added custom workspace name to `//release:generate_workspace_snippet` target.

## Workspace snippet for v999.0.0

```sh
# Generate workspace snippet for tag v999.0.0
bazel run //release:generate_workspace_snippet -- --tag v999.0.0
```

Output:
```python
load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

http_archive(
    name = "buildifier_prebuilt",
    sha256 = "f24270b5e8fe2b1663848c74c452c54609640bfd200f9a5befb6850b8d778a6a",
    strip_prefix = "buildifier-prebuilt-999.0.0",
    urls = [
        "http://github.com/cgrindel/buildifier-prebuilt/archive/v999.0.0.tar.gz",
    ],
)

load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")

buildifier_prebuilt_deps()

load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")

bazel_skylib_workspace()

load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")

buildifier_prebuilt_register_toolchains()
```