### PR TITLE
Upgraded `rules_bazel_integration_test` to use `bazel-contrib` release.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,7 +2,7 @@
 # Trick bazel into treating BUILD files under examples/* as being regular files
 # This lets us glob() up all the files inside the examples to make them inputs to tests
 # (Note, we cannot use `common --deleted_packages` because the bazel version command doesn't support it)
-# To update these lines, run `bazel run @cgrindel_rules_bazel_integration_test//tools:update_deleted_packages`.
+# To update these lines, run `bazel run @contrib_rules_bazel_integration_test//tools:update_deleted_packages`.
 build --deleted_packages=examples/simple,examples/specify_assets
 query --deleted_packages=examples/simple,examples/specify_assets
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,19 +30,19 @@ load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
 bazel_starlib_dependencies()
 
 http_archive(
-    name = "cgrindel_rules_bazel_integration_test",
-    sha256 = "39071d2ec8e3be74c8c4a6c395247182b987cdb78d3a3955b39e343ece624982",
-    strip_prefix = "rules_bazel_integration_test-0.5.0",
+    name = "contrib_rules_bazel_integration_test",
+    sha256 = "ab9bbf776b5874f8a02f639fec2fbb3e3eefa4403cf861ae00d7c7e4d757f9ff",
+    strip_prefix = "rules_bazel_integration_test-0.6.2",
     urls = [
-        "http://github.com/cgrindel/rules_bazel_integration_test/archive/v0.5.0.tar.gz",
+        "http://github.com/bazel-contrib/rules_bazel_integration_test/archive/v0.6.2.tar.gz",
     ],
 )
 
-load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+load("@contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 
 bazel_integration_test_rules_dependencies()
 
+load("@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
-load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
 
 bazel_binaries(versions = SUPPORTED_BAZEL_VERSIONS)

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,10 +1,10 @@
-load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
 load(
-    "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "bazel_integration_tests",
     "default_test_runner",
     "integration_test_utils",
 )
+load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
 
 # Add test for buildozer
 
@@ -22,7 +22,7 @@ sh_binary(
     testonly = True,
     srcs = ["simple_test_runner.sh"],
     data = [
-        "@cgrindel_rules_bazel_integration_test//tools:create_scratch_dir",
+        "@contrib_rules_bazel_integration_test//tools:create_scratch_dir",
     ],
     deps = [
         "@bazel_tools//tools/bash/runfiles",

--- a/examples/simple_test_runner.sh
+++ b/examples/simple_test_runner.sh
@@ -16,7 +16,7 @@ assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
-create_scratch_dir_sh_location=cgrindel_rules_bazel_integration_test/tools/create_scratch_dir.sh
+create_scratch_dir_sh_location=contrib_rules_bazel_integration_test/tools/create_scratch_dir.sh
 create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" || \
   (echo >&2 "Failed to locate ${create_scratch_dir_sh_location}" && exit 1)
 


### PR DESCRIPTION
Related to bazel-contrib/rules_bazel_integration_test#47.