### PR TITLE
Remove joining CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,3 @@ jobs:
     - uses: ./.github/actions/build_and_test
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-
-  all_ci_tests:
-    runs-on: ubuntu-20.04
-    needs: [macos_build, ubuntu_build]
-    steps:
-      - name: All is Well
-        shell: bash
-        run: |
-          echo "All is well!"
-


### PR DESCRIPTION
This was used for branch protection, but since we only have 2 jobs we
can just reference them directly. This removes the need to wait for
agents a little bit.