### PR TITLE
add support for -diff_command

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -18,6 +18,9 @@ def _buildifier(ctx):
     if ctx.attr.lint_mode:
         args.append("-lint=%s" % ctx.attr.lint_mode)
 
+    if ctx.attr.diff_command:
+        args.append("-diff_command=%s" % ctx.attr.diff_command)
+
     if ctx.attr.disabled_rewrites:
         args.append("-buildifier_disable={}".format(",".join(ctx.attr.disabled_rewrites)))
 
@@ -76,6 +79,9 @@ buildifier = rule(
         "lint_warnings": attr.string_list(
             allow_empty = True,
             doc = "all prefixed with +/- if you want to include in or exclude from the default set of warnings, or none prefixed with +/- if you want to override the default set, or 'all' for all available warnings",
+        ),
+        "diff_command": attr.string(
+            doc = "Command to use to show diff, with mode=diff. E.g. 'diff -u'",
         ),
         "add_tables": attr.label(
             mandatory = False,


### PR DESCRIPTION
It seems it's somewhat common to not have `tkdiff` installed (https://github.com/bazelbuild/buildtools/issues/39) and indeed I do not which gives me,
```
$ bazel run //:buildifier.check
INFO: Analyzed target //:buildifier.check (1 packages loaded, 1 target configured).
INFO: Found 1 target...
Target //:buildifier.check up-to-date:
  bazel-bin/buildifier.check.bash
INFO: Elapsed time: 0.047s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
buildifier: selecting diff program with the BUILDIFIER_DIFF, BUILDIFIER_MULTIDIFF, and DISPLAY environment variables is deprecated, use flags -diff_command and -multi_diff instead
./BUILD:
--: line 1: tkdiff: command not found
exit status 127
```