### PR TITLE
README.md: clarify buildtools versions are fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ buildifier_prebuilt_register_toolchains()
 
 ### Specify Version of Buildtools
 
-By default releases of these rules include the most up to date versions of the tools at the current
-time.  If you would like to specify a specific version of buildtools to use, you can do one of the
+By default releases of these rules hardcode the most up to date versions of the tools at release
+time. If you would like to specify a specific version of buildtools to use, you can do one of the
 following.
 
 #### Option 1: Quick and Easy


### PR DESCRIPTION
When I read "current time" I didn't know whether it meant:

* release time
* bazel sync time
* command runtime

Digging in, the version is hardcoded: https://github.com/keith/buildifier-prebuilt/blob/fa9175bbbcbfb5a782d262af73c2cb36b9cab99b/defs.bzl#L39-L41

https://github.com/keith/buildifier-prebuilt/blob/0b8177deda07ab95f69539c5536623b0678a169a/buildtools.bzl#L146-L161

I think this small language tweak helps.