### PR TITLE
Update rules to match bazelbuild/buildtools

### DIFF
--- a/buildifier/factory.bzl
+++ b/buildifier/factory.bzl
@@ -1,0 +1,175 @@
+"""
+This module contains factory methods for simple rule and implementation generation
+"""
+
+load("@bazel_skylib//lib:shell.bzl", "shell")
+
+# buildifier: disable=print
+def _value_deprecation(ctx, attr, value):
+    """
+    Prints a deprecation message related to a specific value for an attr.
+
+    Args:
+      ctx:      The execution context
+      attr:     A String representing the attribute name
+      value:    The deprecated value
+    """
+    print("DEPRECATION NOTICE: value '%s' for attribute '%s' will be removed in the future. Migrate '%s' to buildifier_test." % (value, attr, ctx.label))
+
+# buildifier: disable=print
+def _attr_deprecation(ctx, attr):
+    """
+    Prints an attribute deprecation message.
+
+    Args:
+      ctx:      The execution context
+      attr:     A String representing the deprecated attribute name
+    """
+    print("DEPRECATION NOTICE: attribute '%s' will be removed in the future. Migrate '%s' to buildifier_test." % (attr, ctx.label))
+
+def buildifier_attr_factory(test_rule = False):
+    """
+    Helper macro to generate a struct of attrs for use in a rule() definition.
+
+    Args:
+      test_rule: Whether or not to generate attrs for a test rule.
+
+    Returns:
+      A dictionary of attributes relevant to the rule
+    """
+    attrs = {
+        "buildifier": attr.label(
+            default = "//buildifier",
+            cfg = "exec",
+            executable = True,
+        ),
+        "verbose": attr.bool(
+            doc = "Print verbose information on standard error",
+        ),
+        "mode": attr.string(
+            default = "fix" if not test_rule else "diff",
+            doc = "Formatting mode",
+            values = ["check", "diff", "print_if_changed"] + ["fix"] if not test_rule else [],
+        ),
+        "lint_mode": attr.string(
+            doc = "Linting mode",
+            values = ["", "warn"] + ["fix"] if not test_rule else [],
+        ),
+        "lint_warnings": attr.string_list(
+            allow_empty = True,
+            doc = "all prefixed with +/- if you want to include in or exclude from the default set of warnings, or none prefixed with +/- if you want to override the default set, or 'all' for all available warnings",
+        ),
+        "diff_command": attr.string(
+            doc = "Command to use to show diff, with mode=diff. E.g. 'diff -u'",
+        ),
+        "multi_diff": attr.bool(
+            default = False,
+            doc = "Set to True if the diff command specified by the 'diff_command' can diff multiple files in the style of 'tkdiff'",
+        ),
+        "add_tables": attr.label(
+            mandatory = False,
+            doc = "path to JSON file with custom table definitions which will be merged with the built-in tables",
+            allow_single_file = True,
+        ),
+        "_runner": attr.label(
+            default = "@buildifier_prebuilt//:runner.bash.template",
+            allow_single_file = True,
+        ),
+    }
+
+    if test_rule:
+        attrs.update({
+            "srcs": attr.label_list(
+                allow_empty = False,
+                allow_files = [
+                    ".bazel",
+                    ".bzl",
+                    ".oss",
+                    ".sky",
+                    "BUILD",
+                    "WORKSPACE",
+                ],
+                doc = "A list of labels representing the starlark files to include in the test",
+            ),
+        })
+    else:
+        attrs.update({
+            "exclude_patterns": attr.string_list(
+                allow_empty = True,
+                doc = "A list of glob patterns passed to the find command. E.g. './vendor/*' to exclude the Go vendor directory",
+            ),
+        })
+
+    return attrs
+
+def buildifier_impl_factory(ctx, test_rule = False):
+    """
+    Helper macro to generate a buildifier or buildifier_test rule.
+
+    This macro does not depend on defaults encoded in the binary, instead
+    preferring to set explicit values for each flag.
+
+    Args:
+      ctx:          The execution context.
+      test_rule:    Whether or not to generate a test rule.
+
+    Returns:
+      A DefaultInfo provider
+    """
+
+    if not test_rule and ctx.attr.mode in ["check", "diff", "print_if_changed"]:
+        _value_deprecation(ctx, "mode", ctx.attr.mode)
+
+    args = [
+        "-mode=%s" % ctx.attr.mode,
+        "-v=%s" % str(ctx.attr.verbose).lower(),
+    ]
+
+    if ctx.attr.lint_mode:
+        args.append("-lint=%s" % ctx.attr.lint_mode)
+
+    if ctx.attr.lint_warnings:
+        if not ctx.attr.lint_mode:
+            fail("Cannot pass 'lint_warnings' without a 'lint_mode'")
+        args.append("--warnings={}".format(",".join(ctx.attr.lint_warnings)))
+
+    if ctx.attr.multi_diff:
+        args.append("-multi_diff")
+        if not test_rule:
+            _attr_deprecation(ctx, "multi_diff")
+
+    if ctx.attr.diff_command:
+        args.append("-diff_command=%s" % ctx.attr.diff_command)
+        if not test_rule:
+            _attr_deprecation(ctx, "diff_command")
+
+    if ctx.attr.add_tables:
+        args.append("-add_tables=%s" % ctx.file.add_tables.path)
+
+    exclude_patterns_str = ""
+    if not test_rule and ctx.attr.exclude_patterns:
+        exclude_patterns = ["\\! -path %s" % shell.quote(pattern) for pattern in ctx.attr.exclude_patterns]
+        exclude_patterns_str = " ".join(exclude_patterns)
+
+    out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
+    substitutions = {
+        "@@ARGS@@": shell.array_literal(args),
+        "@@BUILDIFIER_SHORT_PATH@@": shell.quote(ctx.executable.buildifier.short_path),
+        "@@EXCLUDE_PATTERNS@@": exclude_patterns_str,
+    }
+    ctx.actions.expand_template(
+        template = ctx.file._runner,
+        output = out_file,
+        substitutions = substitutions,
+        is_executable = True,
+    )
+
+    runfiles = [ctx.executable.buildifier]
+    if test_rule:
+        runfiles.extend(ctx.files.srcs)
+
+    return DefaultInfo(
+        files = depset([out_file]),
+        runfiles = ctx.runfiles(files = runfiles),
+        executable = out_file,
+    )

--- a/buildifier/factory.bzl
+++ b/buildifier/factory.bzl
@@ -131,7 +131,8 @@ def buildifier_impl_factory(ctx, test_rule = False):
     if ctx.attr.lint_warnings:
         if not ctx.attr.lint_mode:
             fail("Cannot pass 'lint_warnings' without a 'lint_mode'")
-        args.append("--warnings={}".format(",".join(ctx.attr.lint_warnings)))
+        for warning in ctx.attr.lint_warnings:
+            args.append("--warnings={}".format(warning))
 
     if ctx.attr.multi_diff:
         args.append("-multi_diff")

--- a/examples/simple/BUILD
+++ b/examples/simple/BUILD
@@ -1,4 +1,4 @@
-load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test")
 
 buildifier(
     name = "buildifier.check",
@@ -12,7 +12,18 @@ buildifier(
         "all",
         "-cc-native",
     ],
-    mode = "diff",
+)
+
+buildifier_test(
+    name = "buildifier.test",
+    srcs = glob(["**/BUILD"]),
+    lint_mode = "warn",
+    lint_warnings = [
+        # This demonstrates how one can enable all warnings and then disable
+        # select categories.
+        "all",
+        "-cc-native",
+    ],
 )
 
 sh_binary(

--- a/examples/simple/BUILD
+++ b/examples/simple/BUILD
@@ -18,12 +18,6 @@ buildifier_test(
     name = "buildifier.test",
     srcs = glob(["**/BUILD"]),
     lint_mode = "warn",
-    lint_warnings = [
-        # This demonstrates how one can enable all warnings and then disable
-        # select categories.
-        "all",
-        "-cc-native",
-    ],
 )
 
 sh_binary(

--- a/examples/simple/BUILD
+++ b/examples/simple/BUILD
@@ -16,7 +16,7 @@ buildifier(
 
 buildifier_test(
     name = "buildifier.test",
-    srcs = glob(["**/BUILD"]),
+    srcs = ["BUILD"],
     lint_mode = "warn",
 )
 

--- a/examples/specify_assets/BUILD
+++ b/examples/specify_assets/BUILD
@@ -1,4 +1,4 @@
-load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test")
 
 buildifier(
     name = "buildifier.check",
@@ -6,7 +6,12 @@ buildifier(
         "./.git/*",
     ],
     lint_mode = "warn",
-    mode = "diff",
+)
+
+buildifier_test(
+    name = "buildifier.test",
+    srcs = glob(["**/BUILD"]),
+    lint_mode = "warn",
 )
 
 sh_binary(

--- a/rules.bzl
+++ b/rules.bzl
@@ -5,98 +5,44 @@ Rules to use the prebuilt buildifier / buildozer binaries
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("//buildifier:buildifier_binary.bzl", _buildifier_binary = "buildifier_binary")
 load("//buildozer:buildozer_binary.bzl", _buildozer_binary = "buildozer_binary")
+load(
+    "//buildifier:factory.bzl",
+    "buildifier_attr_factory",
+    "buildifier_impl_factory",
+)
 
 buildifier_binary = _buildifier_binary
 buildozer_binary = _buildozer_binary
 
-def _buildifier(ctx):
-    args = [
-        "-mode=%s" % ctx.attr.mode,
-        "-v=%s" % str(ctx.attr.verbose).lower(),
-    ]
+def _buildifier_impl(ctx):
+    return [buildifier_impl_factory(ctx)]
 
-    if ctx.attr.lint_mode:
-        args.append("-lint=%s" % ctx.attr.lint_mode)
-
-    if ctx.attr.diff_command:
-        args.append("-diff_command=%s" % ctx.attr.diff_command)
-
-    if ctx.attr.disabled_rewrites:
-        args.append("-buildifier_disable={}".format(",".join(ctx.attr.disabled_rewrites)))
-
-    if len(ctx.attr.lint_warnings) > 0 and not ctx.attr.lint_mode:
-        fail("Cannot pass 'lint_warnings' without a 'lint_mode'")
-    for warning in ctx.attr.lint_warnings:
-        args.append("--warnings={}".format(warning))
-
-    if ctx.attr.add_tables:
-        args.append("-add_tables=%s" % ctx.file.add_tables.path)
-
-    exclude_patterns_str = ""
-    if ctx.attr.exclude_patterns:
-        exclude_patterns = ["\\! -path %s" % shell.quote(pattern) for pattern in ctx.attr.exclude_patterns]
-        exclude_patterns_str = " ".join(exclude_patterns)
-
-    buildifier = ctx.toolchains["@buildifier_prebuilt//buildifier:toolchain"]._tool
-    out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
-    substitutions = {
-        "@@ARGS@@": shell.array_literal(args),
-        "@@BUILDIFIER_SHORT_PATH@@": shell.quote(buildifier.short_path),
-        "@@EXCLUDE_PATTERNS@@": exclude_patterns_str,
-    }
-    ctx.actions.expand_template(
-        template = ctx.file._runner,
-        output = out_file,
-        substitutions = substitutions,
-        is_executable = True,
-    )
-
-    return DefaultInfo(
-        files = depset([out_file]),
-        runfiles = ctx.runfiles(files = [buildifier]),
-        executable = out_file,
-    )
-
-buildifier = rule(
-    implementation = _buildifier,
-    attrs = {
-        "verbose": attr.bool(
-            doc = "Print verbose information on standard error",
-        ),
-        "mode": attr.string(
-            default = "fix",
-            doc = "Formatting mode",
-            values = ["check", "diff", "print_if_changed", "fix"],
-        ),
-        "lint_mode": attr.string(
-            doc = "Linting mode",
-            values = ["", "warn", "fix"],
-        ),
-        "disabled_rewrites": attr.string_list(
-            allow_empty = True,
-            doc = "buildifier rewrites you want to disable",
-        ),
-        "lint_warnings": attr.string_list(
-            allow_empty = True,
-            doc = "all prefixed with +/- if you want to include in or exclude from the default set of warnings, or none prefixed with +/- if you want to override the default set, or 'all' for all available warnings",
-        ),
-        "diff_command": attr.string(
-            doc = "Command to use to show diff, with mode=diff. E.g. 'diff -u'",
-        ),
-        "add_tables": attr.label(
-            mandatory = False,
-            doc = "path to JSON file with custom table definitions which will be merged with the built-in tables",
-            allow_single_file = True,
-        ),
-        "exclude_patterns": attr.string_list(
-            allow_empty = True,
-            doc = "A list of glob patterns passed to the find command. E.g. './vendor/*' to exclude the Go vendor directory",
-        ),
-        "_runner": attr.label(
-            default = "@buildifier_prebuilt//:runner.bash.template",
-            allow_single_file = True,
-        ),
-    },
+_buildifier = rule(
+    implementation = _buildifier_impl,
+    attrs = buildifier_attr_factory(),
     toolchains = ["@buildifier_prebuilt//buildifier:toolchain"],
     executable = True,
+)
+
+def buildifier(**kwargs):
+    """
+    Wrapper for the _buildifier rule. Adds 'manual' to the tags.
+    Args:
+      **kwargs: all parameters for _buildifier
+    """
+
+    tags = kwargs.get("tags", [])
+    if "manual" not in tags:
+        tags.append("manual")
+        kwargs["tags"] = tags
+    _buildifier(**kwargs)
+
+def _buildifier_test_impl(ctx):
+    return [buildifier_impl_factory(ctx, test_rule = True)]
+
+buildifier_test = rule(
+    implementation = _buildifier_test_impl,
+    attrs = buildifier_attr_factory(True),
+    toolchains = ["@buildifier_prebuilt//buildifier:toolchain"],
+    test = True,
 )

--- a/rules.bzl
+++ b/rules.bzl
@@ -2,7 +2,6 @@
 Rules to use the prebuilt buildifier / buildozer binaries
 """
 
-load("@bazel_skylib//lib:shell.bzl", "shell")
 load("//buildifier:buildifier_binary.bzl", _buildifier_binary = "buildifier_binary")
 load("//buildozer:buildozer_binary.bzl", _buildozer_binary = "buildozer_binary")
 load(


### PR DESCRIPTION
Largely matches the current implementation of bazelbuild/buildtools. I don't necessarily _love_ the new semantics, but this does allow seamless transition between the two.

- Adds buildifier_test
- Removes 'mode' from tests
- Adds srcs to buildifier.tests

#40 