### PR TITLE
Remove manual macro wrapper

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -16,25 +16,12 @@ buildozer_binary = _buildozer_binary
 def _buildifier_impl(ctx):
     return [buildifier_impl_factory(ctx)]
 
-_buildifier = rule(
+buildifier = rule(
     implementation = _buildifier_impl,
     attrs = buildifier_attr_factory(),
     toolchains = ["@buildifier_prebuilt//buildifier:toolchain"],
     executable = True,
 )
-
-def buildifier(**kwargs):
-    """
-    Wrapper for the _buildifier rule. Adds 'manual' to the tags.
-    Args:
-      **kwargs: all parameters for _buildifier
-    """
-
-    tags = kwargs.get("tags", [])
-    if "manual" not in tags:
-        tags.append("manual")
-        kwargs["tags"] = tags
-    _buildifier(**kwargs)
 
 def _buildifier_test_impl(ctx):
     return [buildifier_impl_factory(ctx, test_rule = True)]


### PR DESCRIPTION
This drops the compatibility of automatically marking buildifier targets
as manual, for building this shouldn't be much of an issue since we're
using prebuilt binaries, if you want manual for running add
`tags = ["manual"]` explicitly
