### PR TITLE
Find all *.bazel files for fixing

### DIFF
--- a/runner.bash.template
+++ b/runner.bash.template
@@ -25,14 +25,12 @@ find . \
   @@EXCLUDE_PATTERNS@@ \
   \( -name '*.bzl' \
     -o -name '*.sky' \
-    -o -name BUILD.bazel \
+    -o -name '*.bazel' \
     -o -name BUILD \
     -o -name '*.BUILD' \
-    -o -name 'BUILD.*.bazel' \
     -o -name 'BUILD.*.oss' \
     -o -name WORKSPACE \
-    -o -name WORKSPACE.bazel \
+    -o -name WORKSPACE.bzlmod \
     -o -name WORKSPACE.oss \
-    -o -name 'WORKSPACE.*.bazel' \
     -o -name 'WORKSPACE.*.oss' \
   \) -print | xargs "$buildifier_short_path" "${ARGS[@]}"


### PR DESCRIPTION
This previously didn't discover MODULE.bazel, but realistically anything
with a .bazel extension should be fair game. This also adds
WORKSPACE.bzlmod
