### PR TITLE
Fix passing multiple `lint_warnings` to `buildifier`

### DIFF
--- a/buildifier/factory.bzl
+++ b/buildifier/factory.bzl
@@ -105,8 +105,8 @@ def buildifier_impl_factory(ctx, *, test_rule):
 
     if len(ctx.attr.lint_warnings) > 0 and not ctx.attr.lint_mode:
         fail("Cannot pass 'lint_warnings' without a 'lint_mode'")
-    for warning in ctx.attr.lint_warnings:
-        args.append("--warnings={}".format(warning))
+    if ctx.attr.lint_warnings:
+        args.append("--warnings={}".format(",".join(ctx.attr.lint_warnings)))
 
     if ctx.attr.multi_diff:
         args.append("-multi_diff")

--- a/examples/bzlmod/BUILD
+++ b/examples/bzlmod/BUILD
@@ -7,9 +7,6 @@ buildifier(
     ],
     lint_mode = "warn",
     lint_warnings = [
-        # This demonstrates how one can enable all warnings and then disable
-        # select categories.
-        "all",
         "-cc-native",
     ],
     mode = "diff",

--- a/examples/simple/BUILD
+++ b/examples/simple/BUILD
@@ -7,9 +7,6 @@ buildifier(
     ],
     lint_mode = "warn",
     lint_warnings = [
-        # This demonstrates how one can enable all warnings and then disable
-        # select categories.
-        "all",
         "-cc-native",
     ],
     mode = "diff",


### PR DESCRIPTION
Buildifier accepts a single `--warning` flag with a comma-separated
list of warnings to enable/disable instead of a repeated flag usage.

Also removes mentions of `all - some` warnings in examples as Buildifier
doesn't support this. Due to the bug fixed by this PR, these settings
previously resulted in `default - some`.