### PR TITLE
Fix: Not compatible with --nolegacy_external_runfiles

### DIFF
--- a/buildifier/factory.bzl
+++ b/buildifier/factory.bzl
@@ -142,7 +142,7 @@ def buildifier_impl_factory(ctx, *, test_rule):
 
     substitutions = {
         "@@ARGS@@": shell.array_literal(args) if out_ext == ".bash" else shell.array_literal(args)[1:][:-1].replace("'", ""),
-        "@@BUILDIFIER_SHORT_PATH@@": shell.quote(buildifier.path) if out_ext == ".bash" else buildifier.path,
+        "@@BUILDIFIER_SHORT_PATH@@": shell.quote(buildifier.short_path) if out_ext == ".bash" else buildifier.path,
         "@@EXCLUDE_PATTERNS@@": exclude_patterns_str,
         "@@WORKSPACE@@": workspace,
     }


### PR DESCRIPTION
This PR aims for fixing issue #74.

Tested on M1 Mac 13.4.1 and x86_64 Ubuntu 20.04.6 LTS with buildifier-prebuilt 6.1.2.1 under Bazel 6.3.2, works either with --nolegacy_external_runfiles or not.