### PR TITLE
Use the target platform instead of execution platform when generating…

### DIFF
--- a/buildifier/BUILD
+++ b/buildifier/BUILD
@@ -1,7 +1,8 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(
-    "@buildifier_prebuilt//:rules.bzl",
+    ":buildifier_binary.bzl",
     "buildifier_binary",
+    "buildifier_runner",
 )
 
 bzl_library(
@@ -16,7 +17,18 @@ toolchain_type(
 )
 
 buildifier_binary(
+    name = "current_buildifier_binary",
+    visibility = ["//visibility:public"],
+)
+
+alias(
     name = "buildifier",
+    actual = ":current_buildifier_binary",
+    visibility = ["//visibility:public"],
+)
+
+buildifier_runner(
+    name = "current_buildifier_runner",
     visibility = ["//visibility:public"],
 )
 

--- a/buildifier/buildifier_binary.bzl
+++ b/buildifier/buildifier_binary.bzl
@@ -1,5 +1,5 @@
 """
-Simple rule for running buildifier from the toolchain config
+Simple rule for providing buildifier fro the target platform from the toolchain config
 """
 
 def _buildifier_binary(ctx):
@@ -19,8 +19,21 @@ def _buildifier_binary(ctx):
     ]
 
 buildifier_binary = rule(
+    doc = "Expose the current target platform's buildifier binary",
     implementation = _buildifier_binary,
     attrs = {},
     toolchains = ["@buildifier_prebuilt//buildifier:toolchain"],
     executable = True,
+)
+
+def _buildifier_runner(ctx):
+    return DefaultInfo(
+        files = ctx.toolchains["@buildifier_prebuilt//buildifier:toolchain"]._runner.files,
+    )
+
+buildifier_runner = rule(
+    doc = "Expose the current target platform's buildifier runner template",
+    implementation = _buildifier_runner,
+    attrs = {},
+    toolchains = ["@buildifier_prebuilt//buildifier:toolchain"],
 )

--- a/rules.bzl
+++ b/rules.bzl
@@ -19,7 +19,6 @@ def _buildifier_impl(ctx):
 buildifier = rule(
     implementation = _buildifier_impl,
     attrs = buildifier_attr_factory(test_rule = False),
-    toolchains = ["@buildifier_prebuilt//buildifier:toolchain"],
     executable = True,
 )
 
@@ -29,7 +28,6 @@ def _buildifier_test_impl(ctx):
 _buildifier_test = rule(
     implementation = _buildifier_test_impl,
     attrs = buildifier_attr_factory(test_rule = True),
-    toolchains = ["@buildifier_prebuilt//buildifier:toolchain"],
     test = True,
 )
 

--- a/toolchain.bzl
+++ b/toolchain.bzl
@@ -60,7 +60,7 @@ def declare_toolchain(tool_name, tool, os, arch):  # buildifier: disable=unnamed
         toolchain_type = "@buildifier_prebuilt//{tool}:toolchain".format(
             tool = tool_name,
         ),
-        exec_compatible_with = [
+        target_compatible_with = [
             "@platforms//os:{}".format(os),
             "@platforms//cpu:{}".format(arch),
         ],


### PR DESCRIPTION
When you are producing a binary for a test or executable rule, you must produce it for the current selected target platform.  This is not the case for `buildifier` and `buildifier_test`.

Update the rule to accept the toolchain files via default value attributes instead of a `toolchains` attribute.  Here's a simple example.  On MacOS, you may select a Linux execution platform because your run all your actions via remote execution.  However, buildifier needs to be run locally.  On `buildifier-prebuilt/main`, this is what you'll see:

```
sputt@sputt-mbp2 my_repo % bazel run buildifier 
INFO: Invocation ID: 8a10fad2-96d2-4046-a397-d9afb4890323
INFO: Analyzed target //:buildifier (6 packages loaded, 17 targets configured).
INFO: Found 1 target...
Target //tools/buildifier:buildifier up-to-date:
  bazel-bin/tools/buildifier/buildifier.bash
INFO: Elapsed time: 2.240s, Critical Path: 1.56s
INFO: 4 processes: 4 internal.
INFO: Build completed successfully, 4 total actions
INFO: Running command line: bazel-bin/tools/buildifier/buildifier.bash
/private/var/tmp/_bazel_sputt/ad9530d5bab3fcac80af201dbf653279/external/buildifier_prebuilt~~buildifier_prebuilt_deps_extension~buildifier_linux_amd64/file/buildifier: /private/var/tmp/_bazel_sputt/ad9530d5bab3fcac80af201dbf653279/external/buildifier_prebuilt~~buildifier_prebuilt_deps_extension~buildifier_linux_amd64/file/buildifier: cannot execute binary file
```

Why is it trying to run a Linux executable locally, when my target platform is MacOS?  This is because the toolchain was selected for exec and rendered into the `buildifier` rule.  With this fix applied, we now properly see:
```
sputt@sputt-mbp2 my_repo % bazel run buildifier --override_module=buildifier_prebuilt=/Users/sputt/buildifier-prebuilt
INFO: Invocation ID: 28515c73-802e-4f4c-946a-c3fb1e9e1b7e
INFO: Analyzed target //:buildifier (53 packages loaded, 742 targets configured).
INFO: Found 1 target...
Target //tools/buildifier:buildifier up-to-date:
  bazel-bin/tools/buildifier/buildifier.bash
INFO: Elapsed time: 2.921s, Critical Path: 1.59s
INFO: 4 processes: 4 internal.
INFO: Build completed successfully, 4 total actions
INFO: Running command line: bazel-bin/tools/buildifier/buildifier.bash
(.venv311) sputt@sputt-mbp2 rocket % 
```