### PR TITLE
Fix add_tables as run file target to buildifier

### DIFF
--- a/buildifier/factory.bzl
+++ b/buildifier/factory.bzl
@@ -163,6 +163,8 @@ def buildifier_impl_factory(ctx, *, test_rule):
     )
 
     runfiles = [buildifier]
+    if ctx.attr.add_tables:
+        runfiles.append(ctx.file.add_tables)
     if test_rule:
         runfiles.extend(ctx.files.srcs)
         if ctx.attr.no_sandbox:


### PR DESCRIPTION
This fixes #106 with the same fix as applied upstream to the base buildifier rules.