### PR TITLE
Fix for `--incompatible_no_implicit_file_export`

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -13,7 +13,7 @@ def _buildifier_toolchain_setup_impl(repository_ctx):
         content += """
 declare_toolchain(
     tool_name = "{tool_name}",
-    tool = "@{uniq_name}//file:{tool_name}{ext}",
+    tool = "@{uniq_name}//file",
     os = "{platform}",
     arch = "{arch}",
 )


### PR DESCRIPTION
Currently the toolchain references the downloaded buildifier/buildozer by the downloaded filename and ignores the `filegroup()` generated by `http_file()`. This breaks bazel visibility checking if we try to run `bazel test //.. --incompatible_no_implicit_file_export`.

We are already specifying a `downleaded_file_path` to `http_file()`, so referencing the generated `:file` target will work on all platforms.