### PR TITLE
Fix exec platform for binary targets

### DIFF
--- a/buildifier/buildifier_binary.bzl
+++ b/buildifier/buildifier_binary.bzl
@@ -2,6 +2,8 @@
 Simple rule for running buildifier from the toolchain config
 """
 
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
+
 def _buildifier_binary(ctx):
     buildifier = ctx.toolchains["@buildifier_prebuilt//buildifier:toolchain"]._tool
     script = ctx.actions.declare_file("buildifier")
@@ -21,6 +23,7 @@ def _buildifier_binary(ctx):
 buildifier_binary = rule(
     implementation = _buildifier_binary,
     attrs = {},
+    exec_compatible_with = HOST_CONSTRAINTS,
     toolchains = ["@buildifier_prebuilt//buildifier:toolchain"],
     executable = True,
 )

--- a/buildozer/buildozer_binary.bzl
+++ b/buildozer/buildozer_binary.bzl
@@ -2,6 +2,8 @@
 Simple rule for running buildozer from the toolchain config
 """
 
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
+
 def _buildozer_binary(ctx):
     buildozer = ctx.toolchains["@buildifier_prebuilt//buildozer:toolchain"]._tool
     script = ctx.actions.declare_file("buildozer")
@@ -21,6 +23,7 @@ def _buildozer_binary(ctx):
 buildozer_binary = rule(
     implementation = _buildozer_binary,
     attrs = {},
+    exec_compatible_with = HOST_CONSTRAINTS,
     toolchains = ["@buildifier_prebuilt//buildozer:toolchain"],
     executable = True,
 )


### PR DESCRIPTION
Similar to b60b54e19773d1296719e108949404c756da74f2 but for the binary
rules
