### PR TITLE
bash: use -prune in find

### DIFF
--- a/buildifier/factory.bzl
+++ b/buildifier/factory.bzl
@@ -133,8 +133,8 @@ def buildifier_impl_factory(ctx, *, test_rule):
     if ctx.attr.exclude_patterns:
         if test_rule and not ctx.attr.no_sandbox:
             fail("Cannot use 'exclude_patterns' in a test rule without 'no_sandbox'")
-        exclude_patterns = ["\\! -path %s" % shell.quote(pattern) for pattern in ctx.attr.exclude_patterns]
-        exclude_patterns_str = " ".join(exclude_patterns)
+        exclude_patterns = ["-path %s" % shell.quote(pattern) for pattern in ctx.attr.exclude_patterns]
+        exclude_patterns_str = " -o ".join(exclude_patterns) + " -prune -o "
 
     workspace = ""
     if test_rule and ctx.attr.no_sandbox:

--- a/runner.bash.template
+++ b/runner.bash.template
@@ -31,8 +31,8 @@ fi
 
 # Run buildifier on all starlark files
 find . \
-  -type "${FIND_FILE_TYPE:-f}" \
   @@EXCLUDE_PATTERNS@@ \
+  -type "${FIND_FILE_TYPE:-f}" \
   \( -name '*.bzl' \
     -o -name '*.sky' \
     -o -name '*.bazel' \


### PR DESCRIPTION
Use -prune to handle excluded paths, rather than simply ! -path, which will still visit all subdirectories and files in the excluded paths.

This is more efficient, but more importantly avoids visiting files which may not be readable by the user, which causes `find` fail, and causes buildifier to fail as we are using `-o pipefail`.