### PR TITLE
Optimize the logic of _create_assets

### DIFF
--- a/buildtools.bzl
+++ b/buildtools.bzl
@@ -117,6 +117,65 @@ def _create_assets(
         names: Optional. A `list` of tools to include.
         platforms: Optional. A `list` of platforms to include.
         arches: Optional. A `list` of arches to include.
+        sha256_values: Optional. A `dict` of asset name to sha256.
+
+    Returns:
+        A `list` of buildtools assets.
+    """
+    if version == None:
+        fail("Expected a version.")
+    if names == None or names == []:
+        fail("Expected a non-empty list for names.")
+    if platforms == None or platforms == []:
+        fail("Expected a non-empty list for platforms.")
+    if arches == None or arches == []:
+        fail("Expected a non-empty list for arches.")
+    if sha256_values == None:
+        sha256_values = {}
+
+    assets = []
+    for name in names:
+        for platform in platforms:
+            for arch in arches:
+                if platform == "windows" and arch == "arm64":
+                    continue
+                if platform == "windows" and arch == "riscv64":
+                    continue
+                if platform == "darwin" and arch == "riscv64":
+                    continue
+
+                uniq_name = _create_unique_name(
+                    name = name,
+                    platform = platform,
+                    arch = arch,
+                )
+
+                if uniq_name not in sha256_values:
+                    fail("Missing sha256 value for {}".format(uniq_name))
+
+                assets.append(_create_asset(
+                    name = name,
+                    platform = platform,
+                    arch = arch,
+                    version = version,
+                    sha256 = sha256_values.get(uniq_name),
+                ))
+    return assets
+
+
+def _create_assets_by_sha256_values(
+        version,
+        names = _TOOL_NAMES,
+        platforms = _TYPICAL_PLATFORMS,
+        arches = _TYPICAL_ARCHES,
+        sha256_values = {}):
+    """Create a `list` of asset `struct` values.
+
+    Args:
+        version: The buildtools version string.
+        names: Optional. A `list` of tools to include.
+        platforms: Optional. A `list` of platforms to include.
+        arches: Optional. A `list` of arches to include.
         sha256_values: A `dict` of asset name to sha256.
 
     Returns:
@@ -180,5 +239,6 @@ buildtools = struct(
     asset_to_json = _asset_to_json,
     asset_from_json = _asset_from_json,
     create_assets = _create_assets,
+    create_assets_by_sha256_values = _create_assets_by_sha256_values,
     DEFAULT_ASSETS = _DEFAULT_ASSETS,
 )

--- a/tests/buildtools_tests.bzl
+++ b/tests/buildtools_tests.bzl
@@ -194,10 +194,74 @@ def _create_assets_test(ctx):
 
 create_assets_test = unittest.make(_create_assets_test)
 
+def _create_assets_by_sha256_values_test(ctx):
+    env = unittest.begin(ctx)
+
+    # this example is come from kubevirt, see https://github.com/kubevirt/kubevirt/blob/v1.7.0/WORKSPACE#L84
+    shas = {
+        "buildifier_darwin_amd64": "375f823103d01620aaec20a0c29c6cbca99f4fd0725ae30b93655c6704f44d71",
+        "buildifier_darwin_arm64": "5a6afc6ac7a09f5455ba0b89bd99d5ae23b4174dc5dc9d6c0ed5ce8caac3f813",
+        "buildifier_linux_amd64": "5474cc5128a74e806783d54081f581662c4be8ae65022f557e9281ed5dc88009",
+        "buildifier_linux_arm64": "0bf86c4bfffaf4f08eed77bde5b2082e4ae5039a11e2e8b03984c173c34a561c",
+        "buildifier_linux_s390x": "e2d79ff5885d45274f76531f1adbc7b73a129f59e767f777e8fbde633d9d4e2e",
+        "buildifier_windows_amd64": "370cd576075ad29930a82f5de132f1a1de4084c784a82514bd4da80c85acf4a8",
+        "buildozer_darwin_amd64": "854c9583efc166602276802658cef3f224d60898cfaa60630b33d328db3b0de2",
+        "buildozer_darwin_arm64": "31b1bfe20d7d5444be217af78f94c5c43799cdf847c6ce69794b7bf3319c5364",
+        "buildozer_linux_amd64": "3305e287b3fcc68b9a35fd8515ee617452cd4e018f9e6886b6c7cdbcba8710d4",
+        "buildozer_linux_arm64": "0b5a2a717ac4fc911e1fec8d92af71dbb4fe95b10e5213da0cc3d56cea64a328",
+        "buildozer_linux_s390x": "7e28da8722656e800424989f5cdbc095cb29b2d398d33e6b3d04e0f50bc0bb10",
+        "buildozer_windows_amd64": "58d41ce53257c5594c9bc86d769f580909269f68de114297f46284fbb9023dcf",
+    }
+
+    arches = [
+        "amd64",
+        "arm64",
+        "s390x",
+    ]
+    names = [
+        "buildifier",
+        "buildozer",
+    ]
+    platforms = [
+        "darwin",
+        "linux",
+        "windows",
+    ]
+
+    buildtools.create_assets_by_sha256_values(
+        version = "v7.3.1",
+        arches = arches,
+        names = names,
+        platforms = platforms,
+        sha256_values = shas,
+    )
+
+    # Without the following line, it will cause `create_assets` to fail.
+    shas = shas | {
+        # invalid hash,in order to pass check
+        "buildifier_darwin_s390x": "5101795c6b90e3aca6d8dc4efe15fd818a8b6053f34284551f6ba7fa57ad8415",
+        "buildozer_darwin_s390x": "5101795c6b90e3aca6d8dc4efe15fd818a8b6053f34284551f6ba7fa57ad8415",
+        "buildifier_windows_s390x": "5101795c6b90e3aca6d8dc4efe15fd818a8b6053f34284551f6ba7fa57ad8415",
+        "buildozer_windows_s390x": "5101795c6b90e3aca6d8dc4efe15fd818a8b6053f34284551f6ba7fa57ad8415",
+    }
+
+    buildtools.create_assets(
+        version = "v7.3.1",
+        arches = arches,
+        names = names,
+        platforms = platforms,
+        sha256_values = shas,
+    )
+
+    return unittest.end(env)
+
+create_assets_by_sha256_values_test = unittest.make(_create_assets_by_sha256_values_test)
+
 def buildtools_test_suite():
     return unittest.suite(
         "buildtools_tests",
         create_asset_test,
+        create_assets_by_sha256_values_test,
         create_unique_name_test,
         default_assets_test,
         asset_json_roundtrip_test,


### PR DESCRIPTION
Only create assets based on the passed-in sha256_values.

I recently found that the logic of `_create_assets` needs improvement when using `buildifier-prebuilt`. Projects like `kubevirt` that use `buildifier-prebuilt` require architectures such as s390x, which causes problems with the current `_create_assets` implementation. I believe that creating assets only based on the passed-in `sha256_values` would better align with the expected behavior of this function.

---
**Other Info**
Co-authored by: nijincheng@iscas.ac.cn;