### PR TITLE
Remove fail for missing sha

### DIFF
--- a/buildtools.bzl
+++ b/buildtools.bzl
@@ -7,7 +7,7 @@ load("@bazel_skylib//lib:types.bzl", "types")
 
 _TOOL_NAMES = ["buildifier", "buildozer"]
 _TYPICAL_PLATFORMS = ["windows", "darwin", "linux"]
-_TYPICAL_ARCHES = ["amd64", "arm64", "riscv64"]
+_TYPICAL_ARCHES = ["amd64", "arm64", "riscv64", "s390x"]
 _VALID_TOOL_NAMES = sets.make(_TOOL_NAMES)
 
 def _create_asset(name, platform, arch, version, sha256 = None):
@@ -137,13 +137,6 @@ def _create_assets(
     for name in names:
         for platform in platforms:
             for arch in arches:
-                if platform == "windows" and arch == "arm64":
-                    continue
-                if platform == "windows" and arch == "riscv64":
-                    continue
-                if platform == "darwin" and arch == "riscv64":
-                    continue
-
                 uniq_name = _create_unique_name(
                     name = name,
                     platform = platform,
@@ -151,7 +144,7 @@ def _create_assets(
                 )
 
                 if uniq_name not in sha256_values:
-                    fail("Missing sha256 value for {}".format(uniq_name))
+                    continue
 
                 assets.append(_create_asset(
                     name = name,
@@ -164,9 +157,9 @@ def _create_assets(
 
 _DEFAULT_ASSETS = _create_assets(
     version = "v8.2.1",
-    names = ["buildifier", "buildozer"],
-    platforms = ["darwin", "linux", "windows"],
-    arches = ["amd64", "arm64", "riscv64"],
+    names = _TOOL_NAMES,
+    platforms = _TYPICAL_PLATFORMS,
+    arches = _TYPICAL_ARCHES,
     sha256_values = {
         "buildifier_darwin_amd64": "9f8cffceb82f4e6722a32a021cbc9a5344b386b77b9f79ee095c61d087aaea06",
         "buildifier_darwin_arm64": "cfab310ae22379e69a3b1810b433c4cd2fc2c8f4a324586dfe4cc199943b8d5a",

--- a/tests/buildtools_tests.bzl
+++ b/tests/buildtools_tests.bzl
@@ -194,10 +194,38 @@ def _create_assets_test(ctx):
 
 create_assets_test = unittest.make(_create_assets_test)
 
+def _create_assets_require_all_false_test(ctx):
+    env = unittest.begin(ctx)
+
+    shas = {
+        "buildifier_darwin_amd64": "375f823103d01620aaec20a0c29c6cbca99f4fd0725ae30b93655c6704f44d71",
+        "buildifier_darwin_arm64": "5a6afc6ac7a09f5455ba0b89bd99d5ae23b4174dc5dc9d6c0ed5ce8caac3f813",
+        "buildifier_linux_amd64": "5474cc5128a74e806783d54081f581662c4be8ae65022f557e9281ed5dc88009",
+        "buildifier_linux_arm64": "0bf86c4bfffaf4f08eed77bde5b2082e4ae5039a11e2e8b03984c173c34a561c",
+        "buildifier_linux_s390x": "e2d79ff5885d45274f76531f1adbc7b73a129f59e767f777e8fbde633d9d4e2e",
+        "buildifier_windows_amd64": "370cd576075ad29930a82f5de132f1a1de4084c784a82514bd4da80c85acf4a8",
+    }
+
+    # Missing combinations are skipped
+    assets = buildtools.create_assets(
+        version = "v7.3.1",
+        arches = ["amd64", "arm64", "s390x"],
+        names = ["buildifier"],
+        platforms = ["darwin", "linux", "windows"],
+        sha256_values = shas,
+    )
+
+    asserts.equals(env, 6, len(assets))
+
+    return unittest.end(env)
+
+create_assets_require_all_false_test = unittest.make(_create_assets_require_all_false_test)
+
 def buildtools_test_suite():
     return unittest.suite(
         "buildtools_tests",
         create_asset_test,
+        create_assets_require_all_false_test,
         create_unique_name_test,
         default_assets_test,
         asset_json_roundtrip_test,


### PR DESCRIPTION
If you're calling this manually it's annoying to have to satisfy all
potential combinations, especially as new ones are added.

Fixes https://github.com/keith/buildifier-prebuilt/pull/130
