### PR TITLE
Improve cross exec platform toolchain selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: bazelisk test //:all_integration_tests
+    - name: Run with extra exec platforms
+      run: bazelisk run //:buildifier --extra_execution_platforms=//:non_host_platform,@platforms//host -- -help
 
   example_simple:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: bazelisk test //:all_integration_tests
     - name: Run with extra exec platforms
-      run: bazelisk run //:buildifier --extra_execution_platforms=//:non_host_platform,@platforms//host -- -help
+      run: bazelisk run //:buildifier --extra_execution_platforms=//:non_host_platform,@platforms//host '--' -help
 
   example_simple:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: bazelisk test //:all_integration_tests
     - name: Run with extra exec platforms
-      run: bazelisk run //:buildifier --extra_execution_platforms=//:non_host_platform,@platforms//host '--' -help
+      run: bazelisk run //:buildifier --extra_execution_platforms="//:non_host_platform,@platforms//host" '--' -help
 
   example_simple:
     strategy:

--- a/BUILD
+++ b/BUILD
@@ -58,6 +58,15 @@ alias(
 
 # MARK: - Integration Test
 
+# A platform used for tests that must not match the host platform
+platform(
+    name = "non_host_platform",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:riscv64",
+    ],
+)
+
 filegroup(
     name = "local_repository_files",
     srcs = [

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,7 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "bazel_features", version = "1.45.0")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_shell", version = "0.6.1")

--- a/buildifier/buildifier_binary.bzl
+++ b/buildifier/buildifier_binary.bzl
@@ -5,8 +5,6 @@ Simple rule for running buildifier from the toolchain config
 load("@bazel_features//:features.bzl", "bazel_features")
 load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
 
-_TEST_TOOLCHAIN = bazel_features.toolchains.has_default_test_toolchain_type
-
 def _buildifier_binary(ctx):
     buildifier = ctx.toolchains["@buildifier_prebuilt//buildifier:toolchain"]._tool
     script = ctx.actions.declare_file("buildifier")
@@ -25,11 +23,11 @@ def _buildifier_binary(ctx):
 
 buildifier_binary = rule(
     implementation = _buildifier_binary,
-    exec_compatible_with = [] if _TEST_TOOLCHAIN else HOST_CONSTRAINTS,
+    exec_compatible_with = [] if bazel_features.toolchains.has_default_test_toolchain_type else HOST_CONSTRAINTS,
     toolchains = [
         "@buildifier_prebuilt//buildifier:toolchain",
     ] + ([
         "@bazel_tools//tools/test:default_test_toolchain_type",
-    ] if _TEST_TOOLCHAIN else []),
+    ] if bazel_features.toolchains.has_default_test_toolchain_type else []),
     executable = True,
 )

--- a/buildifier/buildifier_binary.bzl
+++ b/buildifier/buildifier_binary.bzl
@@ -2,7 +2,10 @@
 Simple rule for running buildifier from the toolchain config
 """
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
+
+_TEST_TOOLCHAIN = bazel_features.toolchains.has_default_test_toolchain_type
 
 def _buildifier_binary(ctx):
     buildifier = ctx.toolchains["@buildifier_prebuilt//buildifier:toolchain"]._tool
@@ -22,8 +25,11 @@ def _buildifier_binary(ctx):
 
 buildifier_binary = rule(
     implementation = _buildifier_binary,
-    attrs = {},
-    exec_compatible_with = HOST_CONSTRAINTS,
-    toolchains = ["@buildifier_prebuilt//buildifier:toolchain"],
+    exec_compatible_with = [] if _TEST_TOOLCHAIN else HOST_CONSTRAINTS,
+    toolchains = [
+        "@buildifier_prebuilt//buildifier:toolchain",
+    ] + ([
+        "@bazel_tools//tools/test:default_test_toolchain_type",
+    ] if _TEST_TOOLCHAIN else []),
     executable = True,
 )

--- a/buildifier/factory.bzl
+++ b/buildifier/factory.bzl
@@ -142,7 +142,10 @@ def buildifier_impl_factory(ctx, *, test_rule):
             fail("Cannot use 'no_sandbox' without a 'workspace'")
         workspace = ctx.file.workspace.path
 
-    toolchain = ctx.toolchains["@buildifier_prebuilt//buildifier:toolchain"]
+    if test_rule:
+        toolchain = ctx.exec_groups["test"].toolchains["@buildifier_prebuilt//buildifier:toolchain"]
+    else:
+        toolchain = ctx.toolchains["@buildifier_prebuilt//buildifier:toolchain"]
     buildifier = toolchain._tool
     runner = toolchain._runner
 

--- a/buildozer/buildozer_binary.bzl
+++ b/buildozer/buildozer_binary.bzl
@@ -5,8 +5,6 @@ Simple rule for running buildozer from the toolchain config
 load("@bazel_features//:features.bzl", "bazel_features")
 load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
 
-_TEST_TOOLCHAIN = bazel_features.toolchains.has_default_test_toolchain_type
-
 def _buildozer_binary(ctx):
     buildozer = ctx.toolchains["@buildifier_prebuilt//buildozer:toolchain"]._tool
     script = ctx.actions.declare_file("buildozer")
@@ -25,11 +23,11 @@ def _buildozer_binary(ctx):
 
 buildozer_binary = rule(
     implementation = _buildozer_binary,
-    exec_compatible_with = [] if _TEST_TOOLCHAIN else HOST_CONSTRAINTS,
+    exec_compatible_with = [] if bazel_features.toolchains.has_default_test_toolchain_type else HOST_CONSTRAINTS,
     toolchains = [
         "@buildifier_prebuilt//buildozer:toolchain",
     ] + ([
         "@bazel_tools//tools/test:default_test_toolchain_type",
-    ] if _TEST_TOOLCHAIN else []),
+    ] if bazel_features.toolchains.has_default_test_toolchain_type else []),
     executable = True,
 )

--- a/buildozer/buildozer_binary.bzl
+++ b/buildozer/buildozer_binary.bzl
@@ -2,7 +2,10 @@
 Simple rule for running buildozer from the toolchain config
 """
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
+
+_TEST_TOOLCHAIN = bazel_features.toolchains.has_default_test_toolchain_type
 
 def _buildozer_binary(ctx):
     buildozer = ctx.toolchains["@buildifier_prebuilt//buildozer:toolchain"]._tool
@@ -22,8 +25,11 @@ def _buildozer_binary(ctx):
 
 buildozer_binary = rule(
     implementation = _buildozer_binary,
-    attrs = {},
-    exec_compatible_with = HOST_CONSTRAINTS,
-    toolchains = ["@buildifier_prebuilt//buildozer:toolchain"],
+    exec_compatible_with = [] if _TEST_TOOLCHAIN else HOST_CONSTRAINTS,
+    toolchains = [
+        "@buildifier_prebuilt//buildozer:toolchain",
+    ] + ([
+        "@bazel_tools//tools/test:default_test_toolchain_type",
+    ] if _TEST_TOOLCHAIN else []),
     executable = True,
 )

--- a/deps.bzl
+++ b/deps.bzl
@@ -23,3 +23,11 @@ def buildifier_prebuilt_deps():
         strip_prefix = "rules_shell-0.6.1",
         url = "https://github.com/bazelbuild/rules_shell/releases/download/v0.6.1/rules_shell-v0.6.1.tar.gz",
     )
+
+    maybe(
+        http_archive,
+        name = "bazel_features",
+        sha256 = "adfdb3cffab3a99a63363d844d559a81965d2b61a6062dd51a3d2478d416768f",
+        strip_prefix = "bazel_features-1.45.0",
+        url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.45.0/bazel_features-v1.45.0.tar.gz",
+    )

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -9,6 +9,10 @@ load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")
 
 buildifier_prebuilt_deps()
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()

--- a/examples/specify_assets/WORKSPACE
+++ b/examples/specify_assets/WORKSPACE
@@ -9,6 +9,10 @@ load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")
 
 buildifier_prebuilt_deps()
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()

--- a/rules.bzl
+++ b/rules.bzl
@@ -12,8 +12,6 @@ load(
 )
 load("//buildozer:buildozer_binary.bzl", _buildozer_binary = "buildozer_binary")
 
-_TEST_TOOLCHAIN = bazel_features.toolchains.has_default_test_toolchain_type
-
 buildifier_binary = _buildifier_binary
 buildozer_binary = _buildozer_binary
 
@@ -23,12 +21,12 @@ def _buildifier_impl(ctx):
 buildifier = rule(
     implementation = _buildifier_impl,
     attrs = buildifier_attr_factory(test_rule = False),
-    exec_compatible_with = [] if _TEST_TOOLCHAIN else HOST_CONSTRAINTS,
+    exec_compatible_with = [] if bazel_features.toolchains.has_default_test_toolchain_type else HOST_CONSTRAINTS,
     toolchains = [
         "@buildifier_prebuilt//buildifier:toolchain",
     ] + ([
         "@bazel_tools//tools/test:default_test_toolchain_type",
-    ] if _TEST_TOOLCHAIN else []),
+    ] if bazel_features.toolchains.has_default_test_toolchain_type else []),
     executable = True,
 )
 
@@ -45,7 +43,7 @@ _buildifier_test = rule(
                 "@buildifier_prebuilt//buildifier:toolchain",
             ] + ([
                 "@bazel_tools//tools/test:default_test_toolchain_type",
-            ] if _TEST_TOOLCHAIN else []),
+            ] if bazel_features.toolchains.has_default_test_toolchain_type else []),
         ),
     },
     test = True,

--- a/rules.bzl
+++ b/rules.bzl
@@ -2,6 +2,7 @@
 Rules to use the prebuilt buildifier / buildozer binaries
 """
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
 load("//buildifier:buildifier_binary.bzl", _buildifier_binary = "buildifier_binary")
 load(
@@ -10,6 +11,8 @@ load(
     "buildifier_impl_factory",
 )
 load("//buildozer:buildozer_binary.bzl", _buildozer_binary = "buildozer_binary")
+
+_TEST_TOOLCHAIN = bazel_features.toolchains.has_default_test_toolchain_type
 
 buildifier_binary = _buildifier_binary
 buildozer_binary = _buildozer_binary
@@ -20,8 +23,12 @@ def _buildifier_impl(ctx):
 buildifier = rule(
     implementation = _buildifier_impl,
     attrs = buildifier_attr_factory(test_rule = False),
-    exec_compatible_with = HOST_CONSTRAINTS,
-    toolchains = ["@buildifier_prebuilt//buildifier:toolchain"],
+    exec_compatible_with = [] if _TEST_TOOLCHAIN else HOST_CONSTRAINTS,
+    toolchains = [
+        "@buildifier_prebuilt//buildifier:toolchain",
+    ] + ([
+        "@bazel_tools//tools/test:default_test_toolchain_type",
+    ] if _TEST_TOOLCHAIN else []),
     executable = True,
 )
 
@@ -32,7 +39,15 @@ _buildifier_test = rule(
     implementation = _buildifier_test_impl,
     attrs = buildifier_attr_factory(test_rule = True),
     exec_compatible_with = HOST_CONSTRAINTS,
-    toolchains = ["@buildifier_prebuilt//buildifier:toolchain"],
+    exec_groups = {
+        "test": exec_group(
+            toolchains = [
+                "@buildifier_prebuilt//buildifier:toolchain",
+            ] + ([
+                "@bazel_tools//tools/test:default_test_toolchain_type",
+            ] if _TEST_TOOLCHAIN else []),
+        ),
+    },
     test = True,
 )
 


### PR DESCRIPTION
With bazel 9.x+ we can force the rules being run to be for the target
platform using the default_test_toolchain_type. This shouldn't affect
behavior for older versions. Also adds a test on CI for this case.

Related https://github.com/keith/buildifier-prebuilt/pull/113 https://github.com/keith/buildifier-prebuilt/pull/124

This is trying to work around https://github.com/bazelbuild/bazel/issues/19645
